### PR TITLE
fix: Minor typo in the DATA_LICENSE URI

### DIFF
--- a/climetlab_eumetnet_postprocessing_benchmark/gridded/training_data_forecasts.py
+++ b/climetlab_eumetnet_postprocessing_benchmark/gridded/training_data_forecasts.py
@@ -21,7 +21,7 @@ _terms_of_use = """By downloading data from this dataset, you agree to the terms
     
 and
 
-    https://github.com/Climdyn/climetlab_eumetnet_postprocessing_benchmark/blob/main/DATA_LICENSE
+    https://github.com/Climdyn/climetlab-eumetnet-postprocessing-benchmark/blob/main/DATA_LICENSE
 
 If you do not agree with such terms, do not download the data. """
 


### PR DESCRIPTION
Hy @jodemaey 

Just noticed a minor typo in the `DATA_LICENSE` URI.